### PR TITLE
SciCat PSS integration for PaNOSC

### DIFF
--- a/notebooks/PSS-ESS-SciCat-integration-for-PaNOSC.ipynb
+++ b/notebooks/PSS-ESS-SciCat-integration-for-PaNOSC.ipynb
@@ -1,0 +1,1046 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fb938a2b-c423-421d-aafd-5291213bc020",
+   "metadata": {},
+   "source": [
+    "# PSS ESS SciCat - PaNOSC\n",
+    "## ESS SciCat integration with PaNOSC Search Scoring for PaNOSC Federated Search\n",
+    "\n",
+    "This notebook is an example on how to extract items from the local catalogue system (at ESS is SciCat), populate the PaNOSC Search Scoring (ESS implementation) with the items to be scored.  \n",
+    "Two groups of elements are extracted and imported in PSS: datasets and documents.  \n",
+    "The match with the two type of items that needs to be scored.\n",
+    "\n",
+    "Once we have verified that we the items to be scored in the scoring system, we trigger the weight computation and confirm that they have been computed.\n",
+    "\n",
+    "**Important**: all the current items and weights already present in the database will be deleted.\n",
+    "\n",
+    "**Disclaimer**: this notebook is just as a proof of concept. Use it as is. By using this notebook, you are releasing ESS and its team from any responsability."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66df91c2-7eb0-422d-822d-88ea959048cf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%run PSS-SciCat-for-PaNOSC-common.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1d0a639-8ca5-4e57-9e31-91787cfd8f61",
+   "metadata": {},
+   "source": [
+    "## Retrieve datasets and documents from SciCat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a6d56fa-2456-4419-b746-0945e63f1239",
+   "metadata": {},
+   "source": [
+    "Login in scicat backend.  \n",
+    "Hit login url with username and password, and retrieve JWT token to be used as authentication token in eahc request"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fb42a45-a9a8-46df-bd47-c13a0d848bcf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.post(\n",
+    "    sc_functional_login_url,\n",
+    "    json={\n",
+    "        'username' : username,\n",
+    "        'password' : password\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e56ad861-da38-464f-bb01-913b950f5ac9",
+   "metadata": {},
+   "source": [
+    "Successfull response should report a status code of 200 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b331d3fe-2842-438f-b70d-64d023a20f31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43c491dd-2d05-469e-a9a7-0bdf86da3e20",
+   "metadata": {},
+   "source": [
+    "Extract user id and access token from response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75c81989-f1a4-443c-98fc-358f04e26c88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_res = res.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b7c242e-98d4-440e-a4dd-5120774070e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f31de34-d2fe-4d4f-9f32-4f9e6f8c0316",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "access_token = json_res['id']\n",
+    "user_id = json_res['userId']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1de99695-d080-40c7-b30e-ed32df083ac7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_id, access_token"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a15ab230-b13c-46ed-a6d3-d1f48f043aa0",
+   "metadata": {},
+   "source": [
+    "#### Retrieve all datasets available, retain only the public ones and refactor them to be inserted in the scoring system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e355cb-5383-4b91-a4ea-7b540b00adb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(\n",
+    "    sc_datasets_url,\n",
+    "    headers={\n",
+    "        'Authorization' : 'Bearer ' + access_token\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bede0ef-845d-43d3-ae1b-22006fb2218a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_datasets = res.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72a6fec0-027e-4d9a-b3cc-a53a36450761",
+   "metadata": {},
+   "source": [
+    "List of fields in the first item"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c4c7ff3-d1b5-40f8-94d2-9dcfc8781c57",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "list(raw_datasets[0].keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d427360f-00a9-4e97-ac62-c9ece69acc91",
+   "metadata": {},
+   "source": [
+    "Extract public datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "818cbb65-0ce3-4c48-bd3e-c4829e29337d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_published_datasets = {d['pid']: d for d in raw_datasets if d['isPublished']}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a55a6153-c1df-45d0-87cf-899537859035",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(raw_published_datasets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd8a5a50-1332-4be7-b80d-13f6be7e0161",
+   "metadata": {},
+   "source": [
+    "Prepare dataset to be inserted in the scoring service"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "505c976d-637e-4da2-97e1-a69e4142a7cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prepFields(item,group):\n",
+    "    return {\n",
+    "        k: item[v]\n",
+    "        for k,v\n",
+    "        in meaningful_fields[group].items()\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "596e8550-3894-4f7d-b6af-38f30544e89e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scoring_datasets = [\n",
+    "    {\n",
+    "        'id' : item['pid'],\n",
+    "        'group' : 'datasets',\n",
+    "        'fields' : prepFields(item,'datasets')\n",
+    "    }\n",
+    "    for item \n",
+    "    in raw_published_datasets.values()\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5156376-31de-43f1-a6dc-d810114573d9",
+   "metadata": {},
+   "source": [
+    "Number of items in group Datasets to be inserted in scoring system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8726be3b-5044-4e96-8285-23ef66595f57",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "len(scoring_datasets)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9cb74d0-044d-4f22-8681-7d3b9871b818",
+   "metadata": {},
+   "source": [
+    "#### Retrieve all published data available ( which are mapped to PaNOSC documents) and refactor them to be inserted in the scoring system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "329f16f9-a470-49e3-9deb-100105687ddb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(\n",
+    "    sc_published_data_url + '?access_token=' + access_token\n",
+    ")\n",
+    "\n",
+    "# this csall to the end point does not work\n",
+    "# apparently it does not accept the authorization in the header\n",
+    "#res = requests.get(\n",
+    "#    sc_proposals_url,\n",
+    "#    headers={\n",
+    "#        'Authorization' : 'Bearer ' + access_token\n",
+    "#    }\n",
+    "#)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5e80abd-d956-48db-a737-c1b44fbee160",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74867ad8-4097-4542-9685-4308ae869989",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_published_data = res.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e897fce-35d3-466a-bbaa-40f6fedbc9b6",
+   "metadata": {},
+   "source": [
+    "List of fields in the first item"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bb4337d-c8de-4617-ada2-f129554dd0f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list(raw_published_data[0].keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a1228ba-662d-4fd3-8300-cf822ef8d1a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(raw_published_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ef9049e-d5f2-4d05-a205-8c1460937d6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_published_data[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f60f4e8-6c59-4a25-a3a4-70408cd16cc9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_dataset(pid):\n",
+    "    encoded_pid = urllib.parse.quote_plus(pid)\n",
+    "    res = requests.get(\n",
+    "        sc_datasets_url + '/' + encoded_pid,\n",
+    "        headers={\n",
+    "            'Authorization' : 'Bearer ' + access_token\n",
+    "        }\n",
+    "    )\n",
+    "    return res.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "948c6e63-1007-465f-9c2e-e1644a9d8934",
+   "metadata": {},
+   "source": [
+    "Now retrieve all the datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "928ab71b-3d60-441a-ba8f-96871cd03784",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for pd in raw_published_data:\n",
+    "    pd['datasets'] = [raw_published_datasets[pid] for pid in pd['pidArray'] if pid in raw_published_datasets.keys()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e3213d1-1c95-4b6b-9ca7-acc52ebbabfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extractFieldValue(dk,sk,item):\n",
+    "    #print('extractFieldValue ----------')\n",
+    "    #print(dk)\n",
+    "    #print(sk)\n",
+    "    #print(item)\n",
+    "    output = \"\"\n",
+    "    if type(sk) == dict:\n",
+    "        if type(item[dk]) == list:\n",
+    "            output = [\n",
+    "                prepNestedFields(i,sk)\n",
+    "                for i\n",
+    "                in item[dk]\n",
+    "            ]\n",
+    "        else:\n",
+    "            output =  prepNestedFields(item[dk],sk)\n",
+    "    elif sk in item.keys():\n",
+    "        output = item[sk]\n",
+    "\n",
+    "    return output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38ecb919-4c70-44b1-a6a3-cb87b41eb7ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prepNestedFields(item,fields_list):\n",
+    "    #print('prepNestedFields ----------')\n",
+    "    return {\n",
+    "        dk : extractFieldValue(dk,sk,item)\n",
+    "        for dk,sk\n",
+    "        in fields_list.items()\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6d0e433-1f43-49b6-9c69-26d9bbd6b8be",
+   "metadata": {},
+   "source": [
+    "Prepare proposals to be inserted in the scoring service"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "212e7d6f-9268-49a4-9fbd-a8ea8db4e2ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scoring_documents = [\n",
+    "    {\n",
+    "        'id' : item['doi'],\n",
+    "        'group' : 'documents',\n",
+    "        'fields' : prepNestedFields(item,meaningful_fields['documents'])\n",
+    "    }\n",
+    "    for item \n",
+    "    in raw_published_data\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "339b3b7b-426f-4f37-be36-00231495ba62",
+   "metadata": {},
+   "source": [
+    "Number of items in group Proposals to be inserted in scoring system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05f29c38-e602-4113-901a-3407e154996b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "len(scoring_documents)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f4ed6c6-c3c9-45c0-b156-48bd7a4f73b7",
+   "metadata": {},
+   "source": [
+    "#### Delete all the current items in the scoring system\n",
+    "We do not know if there are any items in scoring system.  \n",
+    "Given that the scoring uses ids from the catalogue, instead of checking and updating each item individually, it is faster to delete everything and insert them once more."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fda93620-5b41-48f0-9fd8-61f0c0335d10",
+   "metadata": {},
+   "source": [
+    "At the moment there is no endpoint for deleting all the items or all the items belonging to a single group.   \n",
+    "We need to retrieve all the items and deleted them one by one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c191714-d095-4d77-96c6-a8bfaeb31ad8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(pss_items_url + \"/count\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba7a5d97-4f32-4e52-b650-93531eab9dd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "count = res.json()['count']\n",
+    "count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05d1c4ce-97fe-490a-aa3e-5fd9418f7dfb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(\n",
+    "    pss_items_url,\n",
+    "    params={\n",
+    "        'limit': count\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4a3ec4a-65ec-422c-b7f5-4d7d1fa124bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_items = res.json() if count else []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc3efb58-986c-4da5-b66a-a20dc218e941",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(current_items)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2cc608e-f7b0-400b-9424-9c6a8b47aa7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delete_res = []\n",
+    "for item in current_items:\n",
+    "    res = requests.delete(\n",
+    "        '/'.join([\n",
+    "            pss_items_url,\n",
+    "            item['id']\n",
+    "        ])\n",
+    "    )\n",
+    "    delete_res.append(res.status_code)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1978b2d3-0941-41a1-ad60-e18c4ac7eb27",
+   "metadata": {},
+   "source": [
+    "Makes sure that all the deletes have been successfull. \n",
+    "We should see only one value matching status code 200."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3517b816-4646-47b4-927d-f744db58a9dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "set(delete_res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af5f6756-23e9-4c58-a2c5-40e52831561f",
+   "metadata": {},
+   "source": [
+    "### Populate items in scoring service\n",
+    "We are inserting both datasets and proposals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97347f6a-9211-4a0b-a628-8f4901c1cdaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(pss_items_url + '/count')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "728e08bc-5bd4-4d35-b49e-0bedd77e5572",
+   "metadata": {},
+   "source": [
+    "We should have zero items in the scoring system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c509123f-1b57-4a49-bfa9-1047c4ffd1ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "count = res.json()['count']\n",
+    "count"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53bc080b-3250-4946-b07a-0721fd41e100",
+   "metadata": {},
+   "source": [
+    "Insert datasets in items.  \n",
+    "Status code returned should be 201 for successful operation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fd33626-f291-4e47-88c1-79bdb5f551bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.post(\n",
+    "    pss_items_url,\n",
+    "    json=scoring_datasets\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "153ff556-fdfa-4da5-a81a-7f9da1a3aa05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5293af73-1356-448d-abe4-9cd5500ed7f0",
+   "metadata": {},
+   "source": [
+    "Insert documents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c94de832-6d4d-4cb8-bd9f-7353f9e4fd7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.post(\n",
+    "    pss_items_url,\n",
+    "    json=scoring_documents\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3e01a2f-6aaf-4512-84b7-3324e9bde6e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ef97c12-b18a-48e1-9c66-b80e60a7fe39",
+   "metadata": {},
+   "source": [
+    "Let's verify that all our items have been created.  \n",
+    "First we request a count of the items, than we verify that we retrieve all the items.  \n",
+    "Finally, we are going to check if we get the two groups."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a09c7d4-3712-4ffa-940b-c17a7a287eac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(pss_items_url + '/count')\n",
+    "count = res.json()['count']\n",
+    "count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1aac4791-8fbb-4ac9-9080-8cdf62e091f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(pss_items_url + \"?limit=\" + str(count+100))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c79912c-c22d-4975-8a33-f79974a26295",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ded706f3-0ee5-4b8f-b10b-3f4faf9b77be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "items = res.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd85b693-9b62-485f-87e9-f22a39296498",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(items)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "534483c3-0f8c-4287-bb68-20e1b3949699",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "set([item['group'] for item in items])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de4280eb-a14e-444f-9f49-17a25ede5cca",
+   "metadata": {},
+   "source": [
+    "### Weight Computation\n",
+    "\n",
+    "Trigger weight computations with a post on the compute endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62234348-65e4-42d4-aa93-13379e5a01dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.post(pss_compute_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "828f6f37-6600-4c7b-b89e-e720b73497ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "038d5b4b-080a-423b-a3db-8f9416aee07c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fe32c97-56ac-4793-bfe5-d87a4142b9e0",
+   "metadata": {},
+   "source": [
+    "The response received from the scoring system informs us that the request has been submitted and received, but not yet started."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1bd923b-f5d0-4992-9c58-90d399535627",
+   "metadata": {},
+   "source": [
+    "We suggest to wait a little bit and than place the request below.  \n",
+    "A get request to the compute endpoint, returns the computation status.  \n",
+    "Re-run the following 3 cells until the computation is done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdb5e46e-5c9b-4a60-81b0-695d20549166",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(pss_compute_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f997913-366c-49a3-bda0-b4b712c796e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79e814ab-0185-48fd-9133-2601f1fdc853",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1cfb5ec-57c4-456c-808b-0e609e08dab2",
+   "metadata": {},
+   "source": [
+    "Computation is done, when all three timestamps fields are assigned and progress is set to 1.0.  \n",
+    "It should look something like the following info:  \n",
+    "`    {`  \n",
+    "`      'requested': '2021-09-28T15:56:19.451171',`  \n",
+    "`      'started': '2021-09-28T15:56:24.468000',`  \n",
+    "`      'ended': '2021-09-28T15:57:00.753000',`  \n",
+    "`      'progressPercent': 1.0,`  \n",
+    "`      'progressDescription': 'Done',`  \n",
+    "`      'inProgress': False`  \n",
+    "`    }`  \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "558cc9db-02b3-42c5-94b3-573f2bc22e85",
+   "metadata": {},
+   "source": [
+    "### Retrieve all weights, count them and check one"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8de7211-abe8-4ca6-ac66-5d0be86615f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(pss_weights_url + '/count')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbcc17d5-c8af-4b4f-9c08-642d5fd974f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d7fb3d0-ee80-49c3-a7fc-a95c1d53b2ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(pss_weights_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "024df441-d8f9-4326-947a-23b8651a55b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weights = res.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c25f192-a61e-4103-9536-9788f33379a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(weights)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e889b98-52cd-4a3c-be7f-e7304621151f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weights[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a97d0c8d-4562-4a19-ba5e-242aa58bf92c",
+   "metadata": {},
+   "source": [
+    "### Retrieve all terms, count them and check one"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26ff0cab-d882-4d23-886d-3805b2a0fa59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(pss_terms_url + '/count')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7bdbab74-5844-48dd-bbbe-29d8700edf8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2451c2e4-6327-4266-b13c-50a602372bc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = requests.get(pss_terms_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3944950a-e849-4b13-9595-5ef6d724ecdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "terms = res.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a63b92b8-7784-453c-bec7-e0dcf79413ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(terms)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd725f92-e22a-409e-8d8c-f09047b07e6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "terms[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08d1ca98-de08-4954-be0a-b8cc4ebf0b87",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/PSS-SciCat-for-PaNOSC-common.ipynb
+++ b/notebooks/PSS-SciCat-for-PaNOSC-common.ipynb
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pss_base_url = \"http://localhost:8000\"\n",
+    "pss_base_url = \"<your-scoring-service-url>\"\n",
     "pss_items_url = '/'.join([pss_base_url,'items'])\n",
     "pss_compute_url = '/'.join([pss_base_url,'compute'])\n",
     "pss_weights_url = '/'.join([pss_base_url,'weights'])"
@@ -101,9 +101,20 @@
     "        'keywords' : 'keywords',\n",
     "        'metadata' : 'scientificMetadata'\n",
     "    },\n",
-    "    'proposals' : {\n",
+    "    'documents' : {\n",
+    "        'doi' : 'doi',\n",
+    "        'creator' : 'creator',\n",
     "        'title' : 'title',\n",
-    "        'abstract' : 'abstract'\n",
+    "        'abstract' : 'abstract',\n",
+    "        'authors' : 'authors',\n",
+    "        'datasets' : {\n",
+    "            'owner' : 'owner',\n",
+    "            'principal investigator' : 'principalInvestigator',\n",
+    "            'keywords' : 'keywords',\n",
+    "            'description' : 'description',\n",
+    "            'title' : 'datasetName',\n",
+    "            'metadata' : 'scientificMetadata'\n",
+    "        }\n",
     "    }\n",
     "}"
    ]
@@ -132,7 +143,9 @@
    "id": "ff076dc5-7a49-401f-a148-ff0c294cd6c0",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import urllib3"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Created new notebook specific for populating PSS from SciCat in the context of PaNOSC.
The new notebooks will populate datasets as before.
PaNOSC documents will be populated with information extracted from SciCat published data and relative public datasets.
This mapping is done in the PaNOSC search api, SciCat implementation.